### PR TITLE
Fix title bar icon path

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -8,7 +8,7 @@
     "width": 800,
     "height": 600,
     "title": "Unofficial WhatsApp",
-    "icon": "icons/icon.png",
+    "icon": "images/icon.png",
     "toolbar": false,
     "show": false
   },


### PR DESCRIPTION
That is the reason why the icon was not being displayed on the top-left
corner (at least on windows). That should fix #15.